### PR TITLE
Ensure Fly deploy uses simplified Dockerfile

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -41,7 +41,7 @@ This document outlines how to deploy the LiveKit Avatar Cockpit frontend to Fly.
    fly deploy
    ```
 
-   The provided Dockerfile only builds the Node.js frontend, avoiding previous references to missing directories that caused `flyctl launch sessions finalize` to fail.
+   The provided Dockerfile only builds the Node.js frontend, avoiding previous references to missing directories that caused `flyctl launch sessions finalize` to fail. The `fly.toml` explicitly points to this Dockerfile so Fly does not try to use older multi-service build instructions.
 
 5. **Verify**
 

--- a/fly.toml
+++ b/fly.toml
@@ -3,6 +3,9 @@ primary_region = "iad"
 kill_signal = "SIGINT"
 kill_timeout = 5
 
+[build]
+  dockerfile = "Dockerfile"
+
 [env]
   PORT = "3000"
 


### PR DESCRIPTION
## Summary
- explicitly tell Fly to build from the minimal frontend Dockerfile
- note the configuration change in the deployment guide so the old multi-service build is not reused

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_b_68de5a59253c832285e238dea3f90527