### PR TITLE
feat: integrate Cartesia avatar service

### DIFF
--- a/QWEN.md
+++ b/QWEN.md
@@ -9,7 +9,7 @@ This is a comprehensive voice AI agent system that combines a Node.js/Express fr
 1. **Frontend (Node.js/Express)**: Serves the Avatar Cockpit UI and handles LiveKit token generation
 2. **Agent (Python)**: LiveKit-based voice agent using OpenAI, Silero, and Deepgram plugins
 3. **LiveKit Integration**: Real-time communication platform for voice/video streaming
-4. **Avatar Visualization**: Ready Player Me integration for avatar previews
+4. **Avatar Visualization**: Cartesia AI integration for avatar previews
 5. **Deployment**: Supports Fly.io and Render deployment with Docker
 
 ### Technologies Used
@@ -19,7 +19,7 @@ This is a comprehensive voice AI agent system that combines a Node.js/Express fr
 - **AI Services**: OpenAI (GPT models, STT, TTS), Deepgram (STT)
 - **Database**: MongoDB (via PyMongo/Motor)
 - **Real-time Communication**: LiveKit
-- **Avatar Service**: Ready Player Me
+- **Avatar Service**: Cartesia AI (face & voice identifiers)
 - **Deployment**: Docker, Fly.io, Render
 
 ## Architecture
@@ -114,6 +114,12 @@ The system consists of three main components working together:
 - `OPENAI_API_KEY`: OpenAI API key for agent functionality
 - `OPENAI_MODEL`: OpenAI model to use (default: gpt-4o-mini)
 - `PORT`: Port for the frontend server (default: 3000)
+- `CARTESIA_API_KEY`: Cartesia API key for avatar rendering (backend only)
+- `CARTESIA_FACE_ID`: Cartesia face identifier used for the cockpit preview
+- `CARTESIA_VOICE_ID`: Cartesia voice identifier presented in the UI
+- `CARTESIA_API_URL` *(optional)*: Override for the Cartesia API base URL (default `https://api.cartesia.ai/v1`)
+- `CARTESIA_FACE_RENDER_PATH` *(optional)*: Path template for Cartesia face renders (default `/faces/{faceId}/render`)
+- `CARTESIA_FACE_RENDER_URL` *(optional)*: Complete URL template (supports `{faceId}` placeholder) for avatar rendering
 
 ## Deployment
 
@@ -135,7 +141,10 @@ The system consists of three main components working together:
      LIVEKIT_URL=wss://your-livekit-host \
      LIVEKIT_API_KEY=lk_api_key \
      LIVEKIT_API_SECRET=lk_api_secret \
-     OPENAI_API_KEY=your_openai_key
+     OPENAI_API_KEY=your_openai_key \
+     CARTESIA_API_KEY=your_cartesia_key \
+     CARTESIA_FACE_ID=cartesia_face_id \
+     CARTESIA_VOICE_ID=cartesia_voice_id
    ```
 
 4. **Deploy**:
@@ -155,7 +164,7 @@ The project includes `render.yaml` for easy deployment to Render:
 ## Key Features
 
 1. **Voice AI Agent**: Real-time voice interaction with AI using STT/TTS
-2. **Avatar Visualization**: Preview Ready Player Me avatars
+2. **Avatar Visualization**: Preview Cartesia AI avatars
 3. **Real-time Communication**: LiveKit-based audio/video streaming
 4. **Data Messaging**: Text chat alongside voice communication
 5. **Responsive UI**: Clean, modern interface for agent interaction

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Voice AI Agent Frontend
 
-This repository contains a lightweight Node.js/Express application that serves an Avatar Cockpit for interacting with a LiveKit-based voice agent. The frontend can request LiveKit access tokens from the backend, connect to a room, exchange data messages, and preview Ready Player Me avatars.
+This repository contains a lightweight Node.js/Express application that serves an Avatar Cockpit for interacting with a LiveKit-based voice agent. The frontend can request LiveKit access tokens from the backend, connect to a room, exchange data messages, and preview Cartesia avatars provisioned via Cartesia AI.
 
 ## Features
 
 - Single-page cockpit UI built with vanilla HTML/CSS/JavaScript.
 - LiveKit token endpoint that signs JWTs with the credentials supplied through environment variables.
 - Real-time status updates and chat view for data messages.
-- Optional Ready Player Me avatar preview support.
+- Integrated Cartesia AI avatar preview fed by environment-provided face and voice identifiers.
 
 ## Requirements
 
@@ -32,6 +32,24 @@ export LIVEKIT_API_SECRET="lk_api_secret"
 ```
 
 If these variables are not present the `/token` endpoint will respond with an error instead of failing silently.
+
+## Cartesia configuration
+
+The cockpit now relies on Cartesia AI for both avatar visuals and voice synthesis metadata. Configure the following environment variables alongside your LiveKit credentials (for production deployments these can be set as Fly.io secrets):
+
+- `CARTESIA_API_KEY` – API key used by the backend to call the Cartesia API. **Do not expose this in the frontend.**
+- `CARTESIA_FACE_ID` – Identifier of the Cartesia face to render in the cockpit preview.
+- `CARTESIA_VOICE_ID` – Identifier of the Cartesia voice associated with the agent.
+- `CARTESIA_API_URL` *(optional)* – Override for the Cartesia API base URL (defaults to `https://api.cartesia.ai/v1`).
+- `CARTESIA_FACE_RENDER_PATH` *(optional)* – Path template used to request the face render (defaults to `/faces/{faceId}/render`).
+- `CARTESIA_FACE_RENDER_URL` *(optional)* – Provide a fully qualified URL (supports `{faceId}` placeholder) if you prefer not to compose the endpoint from base URL and path.
+
+The backend exposes two helper endpoints used by the SPA:
+
+- `GET /cartesia/config` returns a sanitized summary of the configured Cartesia IDs so the UI can surface them without leaking the API key.
+- `GET /cartesia/avatar` proxies the rendered avatar image from Cartesia to the browser.
+
+Without a configured face ID and API key, the refresh button remains disabled and the cockpit displays a notice that the Cartesia avatar is unavailable.
 
 ## Docker Usage
 

--- a/cartesiaClient.js
+++ b/cartesiaClient.js
@@ -1,6 +1,10 @@
 const DEFAULT_API_URL = 'https://api.cartesia.ai/v1';
 const DEFAULT_FACE_RENDER_PATH = '/faces/{faceId}/render';
-const fetchApi = globalThis.fetch;
+let fetchApi = globalThis.fetch;
+if (typeof fetchApi !== 'function') {
+  // Use node-fetch as a fallback in Node.js environments
+  fetchApi = require('node-fetch');
+}
 
 class CartesiaConfigurationError extends Error {
   constructor(message, statusCode = 500) {

--- a/cartesiaClient.js
+++ b/cartesiaClient.js
@@ -1,0 +1,96 @@
+const DEFAULT_API_URL = 'https://api.cartesia.ai/v1';
+const DEFAULT_FACE_RENDER_PATH = '/faces/{faceId}/render';
+const fetchApi = globalThis.fetch;
+
+class CartesiaConfigurationError extends Error {
+  constructor(message, statusCode = 500) {
+    super(message);
+    this.name = 'CartesiaConfigurationError';
+    this.statusCode = statusCode;
+  }
+}
+
+function sanitizeBaseUrl(url) {
+  if (!url) return DEFAULT_API_URL;
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+function resolveFaceRenderPath(faceId) {
+  const template = process.env.CARTESIA_FACE_RENDER_PATH || DEFAULT_FACE_RENDER_PATH;
+  return template.replace('{faceId}', encodeURIComponent(faceId));
+}
+
+function resolveAvatarUrl(faceId) {
+  const explicitUrl = process.env.CARTESIA_FACE_RENDER_URL;
+  if (explicitUrl) {
+    return explicitUrl.replace('{faceId}', encodeURIComponent(faceId));
+  }
+
+  const baseUrl = sanitizeBaseUrl(process.env.CARTESIA_API_URL);
+  const path = resolveFaceRenderPath(faceId);
+  if (!path.startsWith('/')) {
+    return `${baseUrl}/${path}`;
+  }
+  return `${baseUrl}${path}`;
+}
+
+function getPublicConfig() {
+  const voiceId = process.env.CARTESIA_VOICE_ID || null;
+  const faceId = process.env.CARTESIA_FACE_ID || null;
+  return {
+    provider: 'cartesia',
+    voiceId,
+    faceId,
+    voiceConfigured: Boolean(voiceId),
+    faceConfigured: Boolean(faceId && process.env.CARTESIA_API_KEY),
+  };
+}
+
+async function fetchAvatarImage() {
+  const apiKey = process.env.CARTESIA_API_KEY;
+  const faceId = process.env.CARTESIA_FACE_ID;
+
+  if (!faceId) {
+    throw new CartesiaConfigurationError('CARTESIA_FACE_ID is not configured', 503);
+  }
+
+  if (!apiKey) {
+    throw new CartesiaConfigurationError('CARTESIA_API_KEY is not configured', 503);
+  }
+
+  const avatarUrl = resolveAvatarUrl(faceId);
+
+  if (typeof fetchApi !== 'function') {
+    throw new CartesiaConfigurationError('Fetch API is not available in this runtime', 500);
+  }
+
+  const response = await fetchApi(avatarUrl, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      Accept: 'image/*',
+    },
+  });
+
+  if (response.status === 404) {
+    throw new CartesiaConfigurationError('Cartesia avatar asset not found', 404);
+  }
+
+  if (!response.ok) {
+    const payload = await response.text().catch(() => '');
+    throw new Error(`Cartesia avatar request failed with status ${response.status}: ${payload}`);
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  const contentType = response.headers.get('content-type') || 'image/png';
+
+  return {
+    buffer: Buffer.from(arrayBuffer),
+    contentType,
+  };
+}
+
+module.exports = {
+  CartesiaConfigurationError,
+  fetchAvatarImage,
+  getPublicConfig,
+};

--- a/index.html
+++ b/index.html
@@ -129,6 +129,26 @@
         box-shadow: 0 8px 20px rgba(88, 166, 255, 0.25);
       }
 
+      .config-output {
+        display: flex;
+        align-items: center;
+        padding: 0.75rem 0.85rem;
+        border-radius: 10px;
+        border: 1px dashed var(--panel-border);
+        background: rgba(14, 19, 27, 0.75);
+        color: var(--muted);
+        font-family: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+          'Liberation Mono', 'Courier New', monospace;
+        font-size: 0.85rem;
+        min-height: 2.6rem;
+        word-break: break-all;
+      }
+
+      .config-output.configured {
+        border-style: solid;
+        color: var(--accent);
+      }
+
       .status {
         padding: 0.75rem 1rem;
         border-radius: 10px;
@@ -227,11 +247,15 @@
           <div class="controls-row with-buttons">
             <button id="connectBtn">Connect</button>
             <button id="disconnectBtn" disabled>Disconnect</button>
-            <button id="toggleAvatarBtn">Load Avatar</button>
+            <button id="refreshAvatarBtn" disabled>Refresh Cartesia Avatar</button>
           </div>
           <div class="controls-row">
-            <label for="avatarModel">Avatar model (Ready Player Me URL)</label>
-            <input id="avatarModel" placeholder="https://models.readyplayer.me/..." />
+            <label>Cartesia voice ID</label>
+            <div class="config-output" id="cartesiaVoiceId">Loading…</div>
+          </div>
+          <div class="controls-row">
+            <label>Cartesia face ID</label>
+            <div class="config-output" id="cartesiaFaceId">Loading…</div>
           </div>
           <div class="status" id="status">Status: Not connected</div>
         </div>
@@ -296,7 +320,9 @@
         const localVideo = document.getElementById('localVideo');
         const videoPlaceholder = document.getElementById('videoPlaceholder');
         const avatarStage = document.getElementById('avatarStage');
-        const avatarModel = document.getElementById('avatarModel');
+        const refreshAvatarBtn = document.getElementById('refreshAvatarBtn');
+        const voiceIdDisplay = document.getElementById('cartesiaVoiceId');
+        const faceIdDisplay = document.getElementById('cartesiaFaceId');
 
         const dataPacketKind = LiveKit.DataPacket_Kind ?? LiveKit.DataPacketKind;
         const DEFAULT_RELIABLE_KIND = 0;
@@ -305,6 +331,8 @@
           console.warn(`LiveKit DataPacket kind enum missing; defaulting RELIABLE data kind to ${DEFAULT_RELIABLE_KIND}.`);
         }
         let room = null;
+        let cartesiaConfig = { voiceConfigured: false, faceConfigured: false };
+        let avatarObjectUrl = null;
 
         function addMessage(type, text) {
           const wrapper = document.createElement('div');
@@ -319,16 +347,38 @@
           statusEl.textContent = `Status: ${text}`;
         }
 
-        function validateReadyPlayerUrl(url) {
-          try {
-            const parsed = new URL(url);
-            if (!['http:', 'https:'].includes(parsed.protocol)) {
-              return false;
-            }
-            return parsed.hostname.endsWith('readyplayer.me');
-          } catch (error) {
-            return false;
+        function renderConfigValue(element, value, configured = Boolean(value)) {
+          if (!element) return;
+          if (value) {
+            element.textContent = value;
+            element.classList.toggle('configured', configured);
+          } else {
+            element.textContent = 'Not configured';
+            element.classList.remove('configured');
           }
+        }
+
+        function updateAvatarButtonState(forceDisable = false) {
+          if (!refreshAvatarBtn) return;
+          refreshAvatarBtn.disabled = forceDisable || !cartesiaConfig?.faceConfigured;
+        }
+
+        function clearAvatarImage() {
+          if (avatarObjectUrl) {
+            URL.revokeObjectURL(avatarObjectUrl);
+            avatarObjectUrl = null;
+          }
+          avatarStage.style.backgroundImage = 'none';
+          avatarStage.style.backgroundSize = '';
+          avatarStage.style.backgroundPosition = '';
+        }
+
+        function updatePlaceholderVisibility() {
+          if (remoteVideo.style.display !== 'none') {
+            videoPlaceholder.style.display = 'none';
+            return;
+          }
+          videoPlaceholder.style.display = avatarObjectUrl ? 'none' : 'flex';
         }
 
         function detachLocalTracks() {
@@ -341,6 +391,93 @@
                 publication.track.stop();
               }
             });
+        }
+
+        async function refreshCartesiaAvatar() {
+          if (!cartesiaConfig?.faceConfigured) {
+            addMessage('system', 'Cartesia face ID is not available. Check the server configuration.');
+            updateAvatarButtonState();
+            return;
+          }
+
+          if (!refreshAvatarBtn) return;
+
+          const previousLabel = refreshAvatarBtn.textContent;
+          refreshAvatarBtn.textContent = 'Refreshing…';
+          refreshAvatarBtn.disabled = true;
+
+          try {
+            const response = await fetch('/cartesia/avatar', { cache: 'no-store' });
+            if (!response.ok) {
+              let errorMessage = 'Failed to load Cartesia avatar.';
+              try {
+                const payload = await response.json();
+                if (payload?.error) {
+                  errorMessage = payload.error;
+                }
+              } catch (parseError) {
+                console.warn('Non-JSON Cartesia avatar response', parseError);
+              }
+              throw new Error(errorMessage);
+            }
+
+            const blob = await response.blob();
+            clearAvatarImage();
+            avatarObjectUrl = URL.createObjectURL(blob);
+            avatarStage.style.backgroundImage = `url('${avatarObjectUrl}')`;
+            avatarStage.style.backgroundSize = 'cover';
+            avatarStage.style.backgroundPosition = 'center';
+            updatePlaceholderVisibility();
+            addMessage('system', 'Cartesia avatar refreshed.');
+          } catch (error) {
+            console.error('Unable to refresh Cartesia avatar', error);
+            clearAvatarImage();
+            updatePlaceholderVisibility();
+            addMessage('system', `Cartesia avatar error: ${error.message}`);
+          } finally {
+            refreshAvatarBtn.textContent = previousLabel;
+            updateAvatarButtonState();
+          }
+        }
+
+        async function loadCartesiaConfig() {
+          if (voiceIdDisplay) voiceIdDisplay.textContent = 'Loading…';
+          if (faceIdDisplay) faceIdDisplay.textContent = 'Loading…';
+
+          try {
+            const response = await fetch('/cartesia/config', { cache: 'no-store' });
+            if (!response.ok) {
+              throw new Error('Cartesia configuration unavailable');
+            }
+
+            const config = await response.json();
+            cartesiaConfig = config;
+            renderConfigValue(voiceIdDisplay, config.voiceId, config.voiceConfigured);
+            renderConfigValue(faceIdDisplay, config.faceId, config.faceConfigured);
+            updateAvatarButtonState();
+
+            if (config.faceConfigured) {
+              addMessage('system', 'Cartesia face configuration detected.');
+              await refreshCartesiaAvatar();
+            } else {
+              clearAvatarImage();
+              updatePlaceholderVisibility();
+              addMessage('system', 'Cartesia face ID is not configured.');
+            }
+
+            if (config.voiceConfigured) {
+              addMessage('system', 'Cartesia voice ID loaded.');
+            }
+          } catch (error) {
+            console.error('Unable to load Cartesia configuration', error);
+            cartesiaConfig = { voiceConfigured: false, faceConfigured: false };
+            renderConfigValue(voiceIdDisplay, null, false);
+            renderConfigValue(faceIdDisplay, null, false);
+            clearAvatarImage();
+            updatePlaceholderVisibility();
+            updateAvatarButtonState(true);
+            addMessage('system', 'Unable to load Cartesia configuration from the server.');
+          }
         }
 
         async function connect() {
@@ -373,7 +510,7 @@
               if (track.kind === 'video') {
                 track.attach(remoteVideo);
                 remoteVideo.style.display = 'block';
-                videoPlaceholder.style.display = 'none';
+                updatePlaceholderVisibility();
               }
             });
 
@@ -381,7 +518,7 @@
               if (track.kind === 'video') {
                 track.detach();
                 remoteVideo.style.display = 'none';
-                videoPlaceholder.style.display = 'flex';
+                updatePlaceholderVisibility();
               }
             });
 
@@ -442,7 +579,7 @@
           sendBtn.disabled = true;
           remoteVideo.style.display = 'none';
           localVideo.style.display = 'none';
-          videoPlaceholder.style.display = 'flex';
+          updatePlaceholderVisibility();
           setStatus('Not connected');
 
           if (!silent) {
@@ -461,29 +598,14 @@
           messageInput.value = '';
         }
 
-        function toggleAvatarPreview() {
-          const url = avatarModel.value.trim();
-          if (!url) {
-            addMessage('system', 'Provide a Ready Player Me avatar URL to preview it.');
-            return;
-          }
-
-          if (!validateReadyPlayerUrl(url)) {
-            addMessage('system', 'The avatar URL must point to readyplayer.me.');
-            return;
-          }
-
-          avatarStage.style.backgroundImage = `url('https://readyplayer.me/render?model=${encodeURIComponent(url)}&scene=fullbody-portrait')`;
-          avatarStage.style.backgroundSize = 'cover';
-          avatarStage.style.backgroundPosition = 'center';
-          addMessage('system', 'Avatar preview updated.');
-        }
-
         connectBtn.addEventListener('click', connect);
         disconnectBtn.addEventListener('click', () => disconnect(false));
         sendBtn.addEventListener('click', () => sendMessage(reliableDataKind));
-        avatarModel.addEventListener('change', toggleAvatarPreview);
-        document.getElementById('toggleAvatarBtn').addEventListener('click', toggleAvatarPreview);
+        if (refreshAvatarBtn) {
+          refreshAvatarBtn.addEventListener('click', () => {
+            refreshCartesiaAvatar();
+          });
+        }
         messageInput.addEventListener('keydown', (event) => {
           if (event.key === 'Enter') {
             event.preventDefault();
@@ -492,7 +614,9 @@
         });
 
         addMessage('system', 'Welcome! Configure a room and press Connect to begin.');
+        addMessage('system', 'Fetching Cartesia configuration from the server…');
         sendBtn.disabled = true;
+        loadCartesiaConfig();
         window.addEventListener('beforeunload', () => disconnect(true));
       }
 


### PR DESCRIPTION
## Summary
- add a Cartesia API helper and server routes to expose configuration and proxy avatar renders
- replace the Ready Player Me UI controls with Cartesia voice/face metadata and refresh workflow
- document the Cartesia environment variables and deployment requirements

## Testing
- node -e "console.log(require('./cartesiaClient').getPublicConfig())"


------
https://chatgpt.com/codex/tasks/task_b_68e24ca745508322b76acaec34ca31f9